### PR TITLE
Update commit hash to e623120b (includes brand colors and extended su…

### DIFF
--- a/io.github.whelanh.scidCommunity.yml
+++ b/io.github.whelanh.scidCommunity.yml
@@ -61,4 +61,4 @@ modules:
     sources:
       - type: git
         url: https://github.com/whelanh/scidCommunity.git
-        commit: acd0f40db0c122e3546c433833606e1703fdc950
+        commit: e623120b82d1f5e6062b073bacbff7efe6f94f12


### PR DESCRIPTION
Updates the manifest to point to commit e623120b82d1f5e6062b073bacbff7efe6f94f12 which includes:
- Added primary brand colors in appdata.xml
- Extended app summary to meet minimum character requirement
- Various app improvements in latest commit

Fixes Flathub Developer Portal validation errors.