### PR TITLE
Update to v5.1.1.71 with added chessdb.cn_button

### DIFF
--- a/io.github.whelanh.scidCommunity.yml
+++ b/io.github.whelanh.scidCommunity.yml
@@ -61,4 +61,4 @@ modules:
     sources:
       - type: git
         url: https://github.com/whelanh/scidCommunity.git
-        commit: b1c86ec75f40f6bb227004139438af24f4bfcd3c 
+        commit: 3c7d8cbea0a521f7a9c77c343884827e088d2d4c 


### PR DESCRIPTION
This update provides the lastest hash from the upstream repo and adds a feature to the PGN Window (a new button that brings up the chessdb.cn engine-based tree view of the current game position.