### PR TITLE
Update to v5.1.1.75

### DIFF
--- a/io.github.whelanh.scidCommunity.yml
+++ b/io.github.whelanh.scidCommunity.yml
@@ -61,4 +61,4 @@ modules:
     sources:
       - type: git
         url: https://github.com/whelanh/scidCommunity.git
-        commit: 625223409f745af242bb2a7f3fb0c92ebb495dd2 
+        commit: 98433442f4a3afa74c3bc0eef911c8ecfeb4d1a0 


### PR DESCRIPTION
Adds pause/resume button to PGN Window that's only visible when monitoring live Lichess tournament games.