### PR TITLE
Have the Best Games button honor the state of the all_games checkbox

### DIFF
--- a/io.github.whelanh.scidCommunity.yml
+++ b/io.github.whelanh.scidCommunity.yml
@@ -61,4 +61,4 @@ modules:
     sources:
       - type: git
         url: https://github.com/whelanh/scidCommunity.git
-        commit: 3c61a992a530fdf54596a9ea530b6a0fc614c1d2 
+        commit: 72b5cbc66657749b8055ad8b34ca28d8fa45c2b0 


### PR DESCRIPTION
In the Tree View, the "Best Games" button now honors the state of the all_games checkbox.  So if you have filtered the Tree View to show a subset of games in your database, those are the games that will appear in the Best Games window (not all the games in the database).