### PR TITLE
Update to v5.1.2.0

### DIFF
--- a/io.github.whelanh.scidCommunity.yml
+++ b/io.github.whelanh.scidCommunity.yml
@@ -61,4 +61,4 @@ modules:
     sources:
       - type: git
         url: https://github.com/whelanh/scidCommunity.git
-        commit: a2a1d673c91cd99baf0fcff2aa779bdf85ebcfee
+        commit: 550031e16b5b8c78e26f0667a98481ad6a2f076b


### PR DESCRIPTION
User moves in a live Lichess tournament game get moved to a comment when new actually played moves are updated