### PR TITLE
Fix reproducible builds by adding file-prefix-map flags

### DIFF
--- a/io.github.whelanh.scidCommunity.yml
+++ b/io.github.whelanh.scidCommunity.yml
@@ -58,6 +58,10 @@ modules:
 
   - name: scid # main app
     buildsystem: cmake-ninja
+    build-options:
+      env:
+        CFLAGS: -ffile-prefix-map=../=.
+        CXXFLAGS: -ffile-prefix-map=../=.
     sources:
       - type: git
         url: https://github.com/whelanh/scidCommunity.git


### PR DESCRIPTION
Add CFLAGS and CXXFLAGS with -ffile-prefix-map to ensure reproducible builds. This prevents build paths from being embedded in the binary, which was causing the Flathub reprocheck to fail.