### PR TITLE
Update to v5.1.3.62

### DIFF
--- a/io.github.whelanh.scidCommunity.yml
+++ b/io.github.whelanh.scidCommunity.yml
@@ -41,5 +41,5 @@ modules:
     sources:
       - type: git
         url: https://github.com/whelanh/scidCommunity.git
-        commit: 9c2d45e29d42e4bca5bc39599bd39a70b0e74a87
+        commit: 9528bb8b14627a239e5cf433c54135c033dccaf7
         


### PR DESCRIPTION
Fix arrow display if engine started by right-clicking the evaluation bar.