### PR TITLE
Update to v5.1.3.93

### DIFF
--- a/io.github.whelanh.scidCommunity.yml
+++ b/io.github.whelanh.scidCommunity.yml
@@ -41,5 +41,5 @@ modules:
     sources:
       - type: git
         url: https://github.com/whelanh/scidCommunity.git
-        commit: 9531ce0a633c0eebf22e24dbaab96a71b4455ede
+        commit: 90f403c88bd81957a625c2394683e3431260a5b3
         


### PR DESCRIPTION
Make Lichess Eval window moves clickable and auto-refresh (if window left open)